### PR TITLE
Add SeparatorWrap check

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -109,6 +109,10 @@
     <module name="RedundantImport"/>
     <module name="RedundantModifier"/>
     <module name="RightCurly"/>
+    <module name="SeparatorWrap">
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
     <module name="StaticVariableName"/>


### PR DESCRIPTION
This ensures that chained method calls have the dot operator at the
beginning of the line.
