### PR TITLE
authentication support for swiftproxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
 	  <artifactId>commons-io</artifactId>
 	  <version>2.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bouncestorage/swiftproxy/BlobStoreLocator.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/BlobStoreLocator.java
@@ -10,7 +10,5 @@ import java.util.Map;
 import org.jclouds.blobstore.BlobStore;
 
 public interface BlobStoreLocator {
-    String TOKEN_SEPARATOR = "TOKEN";
-
     Map.Entry<String, BlobStore> locateBlobStore(String identity, String container, String blob);
 }

--- a/src/main/java/com/bouncestorage/swiftproxy/BounceResourceConfig.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/BounceResourceConfig.java
@@ -5,15 +5,31 @@
 
 package com.bouncestorage.swiftproxy;
 
+import static com.google.common.base.Throwables.propagate;
+
 import java.net.URI;
 import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.MediaType;
 
+import com.bouncestorage.swiftproxy.v1.InfoResource;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.commons.lang3.RandomStringUtils;
+
 import org.glassfish.jersey.server.ResourceConfig;
+
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BounceResourceConfig extends ResourceConfig {
     private static final Map<String, MediaType> swiftFormatToMediaType = ImmutableMap.of(
@@ -23,30 +39,60 @@ public final class BounceResourceConfig extends ResourceConfig {
             "plain", MediaType.TEXT_PLAIN_TYPE
     );
 
-    private final BlobStore blobStore;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Properties properties;
     private URI endPoint;
     private BlobStoreLocator locator;
+    private Cache<String, BlobStore> tokensToBlobStore = CacheBuilder.newBuilder()
+            .expireAfterWrite(InfoResource.CONFIG.tempauth.token_life, TimeUnit.SECONDS)
+            .build();
 
-    BounceResourceConfig(BlobStore blobStore, BlobStoreLocator locator) {
-        if (blobStore == null && locator == null) {
-            throw new NullPointerException("One of blobStore or locator must be set");
+    BounceResourceConfig(Properties properties, BlobStoreLocator locator) {
+        if (properties == null && locator == null) {
+            throw new NullPointerException("One of properties or locator must be set");
         }
-        this.blobStore = blobStore;
+        this.properties = properties;
         this.locator = locator;
         packages(getClass().getPackage().getName());
     }
 
-    public BlobStore getBlobStore(String identity, String containerName, String blobName) {
+    public String authenticate(String identity, String credential) {
+        BlobStore blobStore = tryAuthenticate(identity, credential);
+        if (blobStore != null) {
+            String token = "AUTH_tk" + RandomStringUtils.randomAlphanumeric(32);
+            tokensToBlobStore.put(token, blobStore);
+            return token;
+        }
+
+        return null;
+    }
+
+    private BlobStore tryAuthenticate(String identity, String credential) {
         if (locator != null) {
-            Map.Entry<String, BlobStore> entry = locator.locateBlobStore(identity, containerName, blobName);
-            if (entry != null) {
+            Map.Entry<String, BlobStore> entry = locator.locateBlobStore(identity, null, null);
+            if (entry != null && entry.getKey().equals(credential)) {
+                logger.debug("blob store for {} found", identity);
                 return entry.getValue();
+            } else {
+                logger.debug("blob store for {} not found", identity);
             }
         }
-        if (blobStore != null) {
-            return blobStore;
+
+        logger.debug("fallback to authenticate with configured provider");
+        try {
+            BlobStoreContext context = ContextBuilder
+                    .newBuilder(properties.getProperty(Constants.PROPERTY_PROVIDER))
+                    .overrides(properties)
+                    .credentials(identity, credential)
+                    .build(BlobStoreContext.class);
+            return context.getBlobStore();
+        } catch (Throwable e) {
+            throw propagate(e);
         }
-        throw new NullPointerException("Blob store not found for: " + identity + " " + containerName + " " + blobName);
+    }
+
+    public BlobStore getBlobStore(String authToken) {
+        return tokensToBlobStore.getIfPresent(authToken);
     }
 
     public static MediaType getMediaType(String format) {

--- a/src/main/java/com/bouncestorage/swiftproxy/Main.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/Main.java
@@ -73,7 +73,7 @@ public final class Main {
         BlobStoreContext context = builder.build(BlobStoreContext.class);
 
         SwiftProxy proxy = SwiftProxy.Builder.builder()
-                .blobStore(context.getBlobStore())
+                .overrides(properties)
                 .endpoint(new URI(proxyEndpoint))
                 .build();
         proxy.start();

--- a/src/main/java/com/bouncestorage/swiftproxy/SwiftProxy.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/SwiftProxy.java
@@ -19,8 +19,6 @@ import javax.ws.rs.ext.RuntimeDelegate;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.filter.LoggingFilter;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
-import org.jclouds.Constants;
-import org.jclouds.blobstore.BlobStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,10 +29,10 @@ public final class SwiftProxy {
     private URI endpoint;
     private final BounceResourceConfig rc;
 
-    public SwiftProxy(BlobStore blobStore, BlobStoreLocator locator, URI endpoint) {
+    public SwiftProxy(Properties properties, BlobStoreLocator locator, URI endpoint) {
         this.endpoint = requireNonNull(endpoint);
 
-        rc = new BounceResourceConfig(blobStore, locator);
+        rc = new BounceResourceConfig(properties, locator);
         if (logger.isDebugEnabled()) {
             rc.register(new LoggingFilter(java.util.logging.Logger.getGlobal(), true));
         }
@@ -70,20 +68,15 @@ public final class SwiftProxy {
     }
 
     public static final class Builder {
-        private BlobStore blobStore;
         private BlobStoreLocator locator;
         private URI endpoint;
+        private Properties properties;
 
         Builder() {
         }
 
         public static Builder builder() {
             return new Builder();
-        }
-
-        public Builder blobStore(BlobStore newBlobStore) {
-            this.blobStore = newBlobStore;
-            return this;
         }
 
         public Builder endpoint(URI newEndpoint) {
@@ -96,11 +89,8 @@ public final class SwiftProxy {
             return this;
         }
 
-        public Builder overrides(Properties properties) {
-            String provider = properties.getProperty(Constants.PROPERTY_PROVIDER);
-            if (provider != null) {
-                blobStore(Utils.storeFromProperties(properties));
-            }
+        public Builder overrides(Properties prop) {
+            this.properties = requireNonNull(prop);
 
             String proxyEndpoint = properties.getProperty(SwiftProxy.PROPERTY_ENDPOINT);
             if (proxyEndpoint != null) {
@@ -115,7 +105,7 @@ public final class SwiftProxy {
         }
 
         public SwiftProxy build() {
-            return new SwiftProxy(blobStore, locator, endpoint);
+            return new SwiftProxy(properties, locator, endpoint);
         }
     }
 }

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/AccountResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/AccountResource.java
@@ -50,7 +50,7 @@ public final class AccountResource extends BlobStoreResource {
                                @HeaderParam("Accept") Optional<String> accept) {
         delimiter.ifPresent(x -> logger.info("delimiter not supported yet"));
 
-        List<ContainerEntry> entries = getBlobStore(getIdentity(authToken), null, null).list()
+        List<ContainerEntry> entries = getBlobStore(authToken).list()
                 .stream()
                 .map(meta -> meta.getName())
                 .filter(name -> marker.map(m -> name.compareTo(m) > 0).orElse(true))

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/AuthResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/AuthResource.java
@@ -13,32 +13,46 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
-import com.bouncestorage.swiftproxy.BlobStoreLocator;
 import com.bouncestorage.swiftproxy.BlobStoreResource;
+import com.bouncestorage.swiftproxy.BounceResourceConfig;
 
 import org.glassfish.grizzly.http.server.Request;
 
+/**
+ * Implements TempAuth (V1 Auth) for Swift. Documentations:
+ * http://docs.openstack.org/developer/swift/overview_auth.html
+ * https://swiftstack.com/docs/cookbooks/swift_usage/auth.html
+ * http://docs.openstack.org/developer/swift/deployment_guide.html
+ */
 @Path("/auth/v1.0")
 public final class AuthResource extends BlobStoreResource {
     @GET
-    public Response auth(@HeaderParam("X-Auth-User") String user,
-                         @HeaderParam("X-Auth-Key") String key,
-                         @HeaderParam("X-Storage-User") String storageUser,
-                         @HeaderParam("X-Storage-Pass") String storagePass,
+    public Response auth(@HeaderParam("X-Auth-User") Optional<String> authUser,
+                         @HeaderParam("X-Auth-Key") Optional<String> authKey,
+                         @HeaderParam("X-Storage-User") Optional<String> storageUser,
+                         @HeaderParam("X-Storage-Pass") Optional<String> storagePass,
                          @HeaderParam("Host") Optional<String> host,
                          @Context Request request) {
-        if (user == null && storageUser != null) {
-            user = storageUser;
+        String identity = authUser.orElseGet(storageUser::get);
+        String credential = authKey.orElseGet(storagePass::get);
+        String authToken = null;
+        try {
+            authToken = ((BounceResourceConfig) application).authenticate(identity, credential);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        if (authToken == null) {
+            return notAuthorized();
         }
 
         String storageURL = host.orElseGet(() -> request.getLocalAddr() + ":" + request.getLocalPort());
         String scheme = request.getScheme();
-        storageURL = scheme + "://" + storageURL + "/v1/" + user;
+        storageURL = scheme + "://" + storageURL + "/v1/AUTH_" + identity;
 
-        String authToken = user + BlobStoreLocator.TOKEN_SEPARATOR + "foobar";
         return Response.ok()
                 .header("x-storage-url", storageURL)
                 .header("x-auth-token", authToken)
+                .header("x-storage-token", authToken)
                 .build();
     }
 }

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/ContainerResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/ContainerResource.java
@@ -52,7 +52,7 @@ public final class ContainerResource extends BlobStoreResource {
             throw new BadRequestException("container name too long");
         }
 
-        getBlobStore(getIdentity(authToken), container, null).createContainerInLocation(null, container);
+        getBlobStore(authToken).createContainerInLocation(null, container);
     }
 
     @POST
@@ -82,7 +82,7 @@ public final class ContainerResource extends BlobStoreResource {
                                   @HeaderParam("X-Detect-Content-Type") boolean detectContentType,
                                   @HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) {
         Response.Status status;
-        BlobStore store = getBlobStore(getIdentity(authToken), container, null);
+        BlobStore store = getBlobStore(authToken);
 
         if (store.containerExists(container)) {
             status = Response.Status.ACCEPTED;
@@ -97,7 +97,7 @@ public final class ContainerResource extends BlobStoreResource {
     @DELETE
     public Response deleteContainer(@NotNull @PathParam("container") String container,
                                     @HeaderParam("X-Auth-Token") String authToken) {
-        BlobStore store = getBlobStore(getIdentity(authToken), container, null);
+        BlobStore store = getBlobStore(authToken);
         if (!store.containerExists(container)) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
@@ -115,7 +115,7 @@ public final class ContainerResource extends BlobStoreResource {
     public Response headContainer(@NotNull @PathParam("container") String container,
                                   @HeaderParam("X-Auth-Token") String authToken,
                                   @HeaderParam("X-Newest") @DefaultValue("false") boolean newest) {
-        BlobStore store = getBlobStore(getIdentity(authToken), container, null);
+        BlobStore store = getBlobStore(authToken);
         if (!store.containerExists(container)) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
@@ -159,7 +159,7 @@ public final class ContainerResource extends BlobStoreResource {
                                   @QueryParam("path") String path,
                                   @HeaderParam("X-Newest") @DefaultValue("false") boolean newest,
                                   @HeaderParam("Accept") String accept) {
-        BlobStore store = getBlobStore(getIdentity(authToken), container, null);
+        BlobStore store = getBlobStore(authToken);
         if (!store.containerExists(container)) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/InfoResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/InfoResource.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("/info")
 public final class InfoResource {
-    static final ServerConfiguration CONFIG = new ServerConfiguration();
+    public static final ServerConfiguration CONFIG = new ServerConfiguration();
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -22,9 +22,11 @@ public final class InfoResource {
         return CONFIG;
     }
 
-    static final class ServerConfiguration {
-        @JsonProperty SwiftConfiguration swift = new SwiftConfiguration();
-        @JsonProperty SLOConfiguration slo = new SLOConfiguration();
+    //CHECKSTYLE:OFF
+    public static final class ServerConfiguration {
+        @JsonProperty public final SwiftConfiguration swift = new SwiftConfiguration();
+        @JsonProperty public final SLOConfiguration slo = new SLOConfiguration();
+        @JsonProperty public final TempAuthConfiguration tempauth = new TempAuthConfiguration();
 
         static final class SwiftConfiguration {
             @JsonProperty final int account_listing_limit = 10000;
@@ -43,7 +45,12 @@ public final class InfoResource {
         }
 
         static final class SLOConfiguration {
-            @JsonProperty int max_manifest_segments = 1000;
+            @JsonProperty final int max_manifest_segments = 1000;
+        }
+
+        public static final class TempAuthConfiguration {
+            @JsonProperty public final int token_life = 85400;
         }
     }
+    //CHECKSTYLE:ON
 }

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/ObjectResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/ObjectResource.java
@@ -147,8 +147,14 @@ public final class ObjectResource extends BlobStoreResource {
                               @HeaderParam("If-None-Match") String ifNoneMatch,
                               @HeaderParam("If-Modified-Since") Date ifModifiedSince,
                               @HeaderParam("If-Unmodified-Since") Date ifUnmodifiedSince) {
+        logger.debug("GET account={} container={} object={}", account, container, object);
+        BlobStore blobStore = getBlobStore(authToken);
+
+        if (!blobStore.containerExists(container)) {
+            return notFound();
+        }
+
         GetOptions options = parseRange(new GetOptions(), range);
-        BlobStore blobStore = getBlobStore(getIdentity(authToken), container, object);
 
         if (ifMatch != null) {
             options.ifETagMatches(ifMatch);
@@ -374,7 +380,7 @@ public final class ObjectResource extends BlobStoreResource {
 
         Map<String, String> additionalUserMeta = getUserMetadata(request);
 
-        BlobStore blobStore = getBlobStore(getIdentity(authToken), container, objectName);
+        BlobStore blobStore = getBlobStore(authToken);
         if (!blobStore.containerExists(container) || !blobStore.containerExists(destContainer)) {
             return notFound();
         }
@@ -449,7 +455,7 @@ public final class ObjectResource extends BlobStoreResource {
             return badRequest();
         }
 
-        BlobStore  blobStore = getBlobStore(getIdentity(authToken), container, objectName);
+        BlobStore  blobStore = getBlobStore(authToken);
         if (!blobStore.containerExists(container)) {
             return notFound();
         }
@@ -579,7 +585,7 @@ public final class ObjectResource extends BlobStoreResource {
         Map<String, String> metadata = getUserMetadata(request);
         InputStream copiedStream = null;
 
-        BlobStore blobStore = getBlobStore(getIdentity(authToken), container, objectName);
+        BlobStore blobStore = getBlobStore(authToken);
         if ("put".equals(multiPartManifest)) {
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
             try (TeeInputStream tee = new TeeInputStream(request.getInputStream(), buffer, true)) {
@@ -650,7 +656,7 @@ public final class ObjectResource extends BlobStoreResource {
             return badRequest();
         }
 
-        BlobStore blobStore = getBlobStore(getIdentity(authToken), container, objectName);
+        BlobStore blobStore = getBlobStore(authToken);
         BlobMetadata meta = blobStore.blobMetadata(container, objectName);
         if (meta == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
@@ -686,7 +692,7 @@ public final class ObjectResource extends BlobStoreResource {
             return badRequest();
         }
 
-        BlobStore store = getBlobStore(getIdentity(authToken), container, objectName);
+        BlobStore store = getBlobStore(authToken);
         if (!store.containerExists(container)) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -138,6 +138,8 @@
     </module>
     <module name="WhitespaceAfter"/>
     <module name="WhitespaceAround"/>
+    <!-- so we can use SuppressionCommentFilter -->
+    <module name="FileContentsHolder"/>
   </module>
   <module name="Header">
     <property name="fileExtensions" value="java"/>
@@ -147,4 +149,5 @@
     <property name="format" value="\s+$"/>
     <property name="message" value="Line has trailing spaces."/>
   </module>
+  <module name="SuppressionCommentFilter"/>
 </module>

--- a/src/test/java/com/bouncestorage/swiftproxy/BlobStoreLocatorTest.java
+++ b/src/test/java/com/bouncestorage/swiftproxy/BlobStoreLocatorTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -68,13 +69,18 @@ public final class BlobStoreLocatorTest {
             return null;
         });
 
+        String path = "/auth/v1.0";
+        Response resp = target.path(path).request().header("X-auth-user", "foo").header("X-auth-key", "foo")
+                .get();
+        String storageURL = resp.getHeaderString("x-storage-url");
+        String authToken = resp.getHeaderString("x-auth-token");
+        assertThat(storageURL).isNotNull();
+        assertThat(authToken).isNotNull();
         String container = "container";
-        String path = Joiner.on("/").join(TestUtils.ACCOUNT_PATH, container);
-        target.path(path).request().header("X-auth-token", "foo" + BlobStoreLocator.TOKEN_SEPARATOR + "token")
-                .post(null);
-        target.path(path).request().header("X-auth-token", "bar" + BlobStoreLocator.TOKEN_SEPARATOR + "token")
+        path = Joiner.on("/").join(TestUtils.ACCOUNT_PATH, container);
+        target.path(path).request().header("X-auth-token", authToken)
                 .post(null);
         assertThat(foo.containerExists(container)).isTrue();
-        assertThat(bar.containerExists(container)).isTrue();
+        assertThat(bar.containerExists(container)).isFalse();
     }
 }

--- a/src/test/java/com/bouncestorage/swiftproxy/TestUtils.java
+++ b/src/test/java/com/bouncestorage/swiftproxy/TestUtils.java
@@ -7,13 +7,17 @@ package com.bouncestorage.swiftproxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import com.google.common.io.Resources;
+
+import org.jclouds.Constants;
 
 public final class TestUtils {
     public static final String ACCOUNT_PATH = "/v1/testAccount";
@@ -35,14 +39,39 @@ public final class TestUtils {
         return proxy;
     }
 
-    public static Response deleteContainer(WebTarget target, String container) {
-        return target.path(ACCOUNT_PATH + "/" + container)
-                .request().delete();
+    public static String getAuthToken(WebTarget target) {
+        Properties properties = new Properties();
+        try (InputStream is = Resources.asByteSource(Resources.getResource(
+                "swiftproxy.conf")).openStream()) {
+            properties.load(is);
+        } catch (IOException e) {
+            return null;
+        }
+
+        Response resp = target.path("/auth/v1.0").request()
+                .header("X-auth-user", properties.getProperty(Constants.PROPERTY_IDENTITY))
+                .header("X-auth-key", properties.getProperty(Constants.PROPERTY_CREDENTIAL))
+                .get();
+        return resp.getHeaderString("x-auth-token");
     }
 
-    public static void createContainer(WebTarget target, String container) {
-        Response resp = target.path(ACCOUNT_PATH + "/" + container)
-                .request().post(null);
+    public static Response deleteContainer(WebTarget target, String container) throws Exception {
+        return deleteContainer(target, container, Optional.empty());
+    }
+
+    public static Response deleteContainer(WebTarget target, String container,
+                                           Optional<String> authToken) throws Exception {
+        return target.path(ACCOUNT_PATH + "/" + container).request()
+                .header("x-auth-token", authToken.orElseGet(() -> getAuthToken(target)))
+                .delete();
+    }
+
+    public static String createContainer(WebTarget target, String container) throws Exception {
+        String authToken = getAuthToken(target);
+        Response resp = target.path(ACCOUNT_PATH + "/" + container).request()
+                .header("x-auth-token", authToken)
+                .post(null);
         assertThat(resp.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+        return authToken;
     }
 }

--- a/src/test/java/com/bouncestorage/swiftproxy/v1/AccountResourceTest.java
+++ b/src/test/java/com/bouncestorage/swiftproxy/v1/AccountResourceTest.java
@@ -8,6 +8,7 @@ package com.bouncestorage.swiftproxy.v1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -49,9 +50,9 @@ public final class AccountResourceTest {
 
     @Test
     public void testOneContainer() throws Exception {
-        TestUtils.createContainer(target, CONTAINER);
+        String authToken = TestUtils.createContainer(target, CONTAINER);
 
-        List<AccountResource.ContainerEntry> entries = listContainers();
+        List<AccountResource.ContainerEntry> entries = listContainers(Optional.of(authToken));
         assertThat(entries).containsOnly(new AccountResource.ContainerEntry(CONTAINER));
     }
 
@@ -61,10 +62,15 @@ public final class AccountResourceTest {
         assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
     }
 
-    List<AccountResource.ContainerEntry> listContainers() {
+    List<AccountResource.ContainerEntry> listContainers() throws Exception {
+        return listContainers(Optional.empty());
+    }
+
+    List<AccountResource.ContainerEntry> listContainers(Optional<String> authToken) throws Exception {
         return target.path(TestUtils.ACCOUNT_PATH)
                 .queryParam("format", "json")
                 .request()
+                .header("x-auth-token", authToken.orElseGet(() -> TestUtils.getAuthToken(target)))
                 .get(new GenericType<List<AccountResource.ContainerEntry>>() {
                 });
     }

--- a/src/test/java/com/bouncestorage/swiftproxy/v1/ContainerResourceTest.java
+++ b/src/test/java/com/bouncestorage/swiftproxy/v1/ContainerResourceTest.java
@@ -7,6 +7,8 @@ package com.bouncestorage.swiftproxy.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -43,25 +45,26 @@ public final class ContainerResourceTest {
         Response resp = TestUtils.deleteContainer(target, CONTAINER);
         assertThat(resp.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
 
-        TestUtils.createContainer(target, CONTAINER);
+        String authToken = TestUtils.createContainer(target, CONTAINER);
 
-        resp = TestUtils.deleteContainer(target, CONTAINER);
+        resp = TestUtils.deleteContainer(target, CONTAINER, Optional.of(authToken));
         assertThat(resp.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
     }
 
     @Test
     public void testHeadContainer() throws Exception {
-        Response resp = headContainer(CONTAINER);
+        Response resp = headContainer(CONTAINER, Optional.empty());
         assertThat(resp.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
 
-        TestUtils.createContainer(target, CONTAINER);
+        String authToken = TestUtils.createContainer(target, CONTAINER);
 
-        resp = headContainer(CONTAINER);
+        resp = headContainer(CONTAINER, Optional.of(authToken));
         assertThat(resp.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
     }
 
-    Response headContainer(String container) {
-        return target.path(TestUtils.ACCOUNT_PATH + "/" + container)
-                .request().head();
+    Response headContainer(String container, Optional<String> authToken) {
+        return target.path(TestUtils.ACCOUNT_PATH + "/" + container).request()
+                .header("x-auth-token", authToken.orElseGet(() -> TestUtils.getAuthToken(target)))
+                .head();
     }
 }


### PR DESCRIPTION
authentication requests are forwarded to the underly blobstore, or
validated via the BlobLocator interface. On success, SwiftProxy
generates and returns a auth token, which is valid for (by default)
24 hours. Subsequent requests with the same auth token will be
forwarded to the same blob store.

Fixes #18
