### PR TITLE
Handle ContainerNotFound exception in ObjectResource HEAD

### DIFF
--- a/src/main/java/com/bouncestorage/swiftproxy/ContainerNotFoundExceptionMapper.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/ContainerNotFoundExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Bounce Storage, Inc. <info@bouncestorage.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bouncestorage.swiftproxy;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.glassfish.jersey.spi.ExtendedExceptionMapper;
+import org.jclouds.blobstore.ContainerNotFoundException;
+
+@Provider
+public class ContainerNotFoundExceptionMapper implements ExtendedExceptionMapper<ContainerNotFoundException> {
+    @Override
+    public final Response toResponse(ContainerNotFoundException exception) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    @Override
+    public final boolean isMappable(ContainerNotFoundException e) {
+        return true;
+    }
+}

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/AccountResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/AccountResource.java
@@ -44,6 +44,8 @@ import com.bouncestorage.swiftproxy.BounceResourceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.jclouds.blobstore.domain.StorageMetadata;
+
 @Singleton
 @Path("/v1/{account}")
 public final class AccountResource extends BlobStoreResource {
@@ -63,12 +65,12 @@ public final class AccountResource extends BlobStoreResource {
 
         List<ContainerEntry> entries = getBlobStore(authToken).list()
                 .stream()
-                .map(meta -> meta.getName())
+                .map(StorageMetadata::getName)
                 .filter(name -> marker.map(m -> name.compareTo(m) > 0).orElse(true))
                 .filter(name -> endMarker.map(m -> name.compareTo(m) < 0).orElse(true))
-                .filter(name -> prefix.map(p -> name.startsWith(p)).orElse(true))
+                .filter(name -> prefix.map(name::startsWith).orElse(true))
                 .limit(limit.orElse(Integer.MAX_VALUE))
-                .map(name -> new ContainerEntry(name))
+                .map(ContainerEntry::new)
                 .collect(Collectors.toList());
 
         MediaType formatType = BounceResourceConfig.getMediaType(format.orElse(accept.orElse(null)));


### PR DESCRIPTION
When processing HEAD for a blob, we should handle the ContainerNotFound exception.