### PR TITLE
bulk-delete fixes

### DIFF
--- a/src/test/java/com/bouncestorage/swiftproxy/v1/AccountResourceTest.java
+++ b/src/test/java/com/bouncestorage/swiftproxy/v1/AccountResourceTest.java
@@ -82,7 +82,9 @@ public final class AccountResourceTest {
 
         String[] removeObjects = {"/test/bar", "/test"};
         Response response = target.path(TestUtils.ACCOUNT_PATH)
-                .queryParam("bulk-delete", "true")
+                // swift actually sends ?bulk-delete and this sends ?bulk-delete=, but
+                // that's the closest we can get
+                .queryParam("bulk-delete", "")
                 .request()
                 .header("X-Auth-Token", authToken)
                 .post(Entity.entity(Joiner.on("\n").join(removeObjects), MediaType.TEXT_PLAIN));


### PR DESCRIPTION
jclouds and swift documentation passes ?bulk-delete without param value
to indicate bulk-delete.

jclouds doesn't pass the initial / to payload

jclouds doesn't escape payload strings correctly, which swift seems to
accept. Included a transient backend workaround for this