### PR TITLE
Fix application/directory handling in SwiftProxy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
    - python-virtualenv
    - python-dev
    - libffi-dev
-   - python-swiftclient
 jdk:
   - oraclejdk8
 script:

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/ContainerResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/ContainerResource.java
@@ -60,6 +60,7 @@ import com.fasterxml.jackson.databind.ser.std.DateSerializer;
 import com.google.common.base.Strings;
 
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.options.ListContainerOptions;
@@ -157,6 +158,12 @@ public final class ContainerResource extends BlobStoreResource {
     }
 
     private String contentType(StorageMetadata meta) {
+        if (meta instanceof BlobMetadata) {
+            String contentType = ((BlobMetadata) meta).getContentMetadata().getContentType();
+            if (contentType != null && !contentType.isEmpty()) {
+                return contentType;
+            }
+        }
         if (meta.getType().equals(StorageType.RELATIVE_PATH) || meta.getName().endsWith("/")) {
             return "application/directory";
         }

--- a/src/main/java/com/bouncestorage/swiftproxy/v1/ObjectResource.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/v1/ObjectResource.java
@@ -374,15 +374,6 @@ public final class ObjectResource extends BlobStoreResource {
         return objectName;
     }
 
-    private static String contentType(String contentType) {
-        // workaround the stupidity in jclouds where it always strip trailing / from
-        // blob name listings. this allows us to detect that it's happened
-        if ("application/directory".equals(contentType)) {
-            return "application/x-directory";
-        }
-        return contentType;
-    }
-
     private Map<String, String> getUserMetadata(Request request) {
         return StreamSupport.stream(request.getHeaderNames().spliterator(), false)
                 .filter(name -> name.toLowerCase().startsWith(META_HEADER_PREFIX.toLowerCase()))
@@ -743,7 +734,7 @@ public final class ObjectResource extends BlobStoreResource {
                 builder.contentEncoding(contentEncoding);
             }
             if (contentType != null) {
-                builder.contentType(contentType(contentType.toString()));
+                builder.contentType(contentType.toString());
             }
             if (contentLengthParam != null) {
                 builder.contentLength(contentLength);


### PR DESCRIPTION
The patch changes two behaviors in SwiftProxy:
1. If a listed blob includes its Content-Type, SwiftProxy should use
   that type verbatim. Previously, SwiftProxy would always attempt to
   infer if a blob is a directory or a regular blob, resulting in
   mislabeling of the special directory blobs in Swift
   (application/directory Content-Type).
2. When creating a blob with application/directory Content-Type,
   SwiftProxy should not change the type to x-application/directory.