### PR TITLE
Crawl folders in Google Cloud Storage

### DIFF
--- a/src/main/java/com/bouncestorage/swiftproxy/Utils.java
+++ b/src/main/java/com/bouncestorage/swiftproxy/Utils.java
@@ -133,18 +133,14 @@ public final class Utils {
                     advance();
                     continue;
                 }
-                try {
-                    StorageMetadata metadata = iterator.next();
-                    // filter out folders with atmos and filesystem providers
-                    if (metadata.getType() == StorageType.RELATIVE_PATH) {
-                        continue;
-                    }
-                    return metadata;
-                } catch (NullPointerException e) {
-                    NullPointerException e2 = new NullPointerException("marker " + marker);
-                    e2.initCause(e);
-                    throw e2;
+
+                StorageMetadata metadata = iterator.next();
+                // filter out folders with atmos and filesystem providers
+                // accept metadata == null for Google Cloud Storage folders
+                if (metadata == null || metadata.getType() == StorageType.RELATIVE_PATH) {
+                    continue;
                 }
+                return metadata;
             }
         }
     }


### PR DESCRIPTION
When crawling a Google Cloud Storage container, ensure that no
NullPointerException is thrown.